### PR TITLE
fix: update github actions checkout ref to main

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: github action checkout
         uses: actions/checkout@v4.2.2
-
         with:
           fetch-depth: 0
+          ref: main
 
       - name: use Node 20
         uses: actions/setup-node@v4.4.0


### PR DESCRIPTION
## 개요 
GitHub Actions CD 배포 안되는 문제 수정
## 이슈 번호

- resolved #78 

## 변경사항 
GitHub Actions CD 배포 안되는 문제 수정